### PR TITLE
Fix path handling

### DIFF
--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -157,8 +157,7 @@ class CookieStore {
     List<Cookie> ret = [];
     for (Cookie cookie in cookies) {
       if (_domainMatches(cookie.domain, requestDomain) &&
-          (pathMatches(cookie.path, requestPath) ||
-              pathMatches(requestPath, cookie.path))) {
+          pathMatches(requestPath, cookie.path)) {
         ret.add(cookie);
       }
     }

--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -352,28 +352,32 @@ class CookieStore {
 
       // Parse the date, I'm trying to be as permissive as possible. I hate
       // the internet so fucking much
+      String expires = attrs["expires"]!;
+
+      final Iterable<({String fullname, String abbreviation})> weekdays = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+      ].map((e) => (fullname: e, abbreviation: e.substring(0, 3)));
+
       try {
-        cookie.expiryTime = HttpDate.parse(attrs["expires"]!);
+        cookie.expiryTime = HttpDate.parse(expires);
       } catch (e) {
-        attrs["expires"] = attrs["expires"]!.replaceAll("Mon", "Monday");
-        attrs["expires"] = attrs["expires"]!.replaceAll("Tue", "Tuesday");
-        attrs["expires"] = attrs["expires"]!.replaceAll("Wed", "Wednesday");
-        attrs["expires"] = attrs["expires"]!.replaceAll("Thu", "Thursday");
-        attrs["expires"] = attrs["expires"]!.replaceAll("Fri", "Friday");
-        attrs["expires"] = attrs["expires"]!.replaceAll("Sat", "Saturday");
-        attrs["expires"] = attrs["expires"]!.replaceAll("Sun", "Sunday");
+        for (final replacement in weekdays) {
+          expires = expires.replaceAll(replacement.abbreviation, replacement.fullname);
+        }
         try {
-          cookie.expiryTime = HttpDate.parse(attrs["expires"]!);
+          cookie.expiryTime = HttpDate.parse(expires);
         } catch (e) {
-          attrs["expires"] = attrs["expires"]!.replaceAll("Monday", "Mon");
-          attrs["expires"] = attrs["expires"]!.replaceAll("Tuesday", "Tue");
-          attrs["expires"] = attrs["expires"]!.replaceAll("Wednesday", "Wed");
-          attrs["expires"] = attrs["expires"]!.replaceAll("Thursday", "Thu");
-          attrs["expires"] = attrs["expires"]!.replaceAll("Friday", "Fri");
-          attrs["expires"] = attrs["expires"]!.replaceAll("Saturday", "Sat");
-          attrs["expires"] = attrs["expires"]!.replaceAll("Sunday", "Sun");
+          for (final replacement in weekdays) {
+            expires = expires.replaceAll(replacement.fullname, replacement.abbreviation);
+          }
           try {
-            cookie.expiryTime = HttpDate.parse(attrs["expires"]!);
+            cookie.expiryTime = HttpDate.parse(expires);
           } catch (e) {
             return false;
           }

--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -208,7 +208,7 @@ class CookieStore {
   /// the algorithm in RFC6265 section 5.2.
   ///
   /// [name] is the cookie name, [value] is the cookie value, and [attrs] are
-  /// attributes in key-value form, lowercase.
+  /// attributes in key-value form.
   ///
   /// May throw a [FormatException] if [header] is malformed
   ///
@@ -312,7 +312,7 @@ class CookieStore {
   }
 
   /// Process given Set-Cookie and add to [cookies].
-  /// It must be already broken down to name, value, and lowercase attributes
+  /// It must be already broken down to name, value, and attributes
   ///
   /// @return whether the cookie was accepted
   bool _processCookie(
@@ -322,6 +322,9 @@ class CookieStore {
     String requestDomain,
     String requestPath,
   ) {
+    bool containsKey(String key) => attrs.containsKey(key) || attrs.containsKey(key.toLowerCase());
+    String? attr(String key) => attrs[key] ?? attrs[key.toLowerCase()];
+
     // Go through the steps in RFC 6265 section 5.3
 
     // Step 1
@@ -331,12 +334,12 @@ class CookieStore {
     Cookie cookie = Cookie(name, value);
 
     // Step 3
-    if (attrs.containsKey("max-age")) {
+    if (containsKey("Max-Age")) {
       // If Max-Age is present:
       // Cookie is persistent
       cookie.persistent = true;
       // Value is the max age in seconds (or -1)
-      int seconds = int.parse(attrs["max-age"]!);
+      int seconds = int.parse(attr("Max-Age")!);
       if (seconds > 0) {
         // If the max age is not -1, calculate expiry time
         cookie.expiryTime = cookie.creationTime.add(Duration(seconds: seconds));
@@ -344,7 +347,7 @@ class CookieStore {
         // If the max age -1, set expiry time to 1 Jan 1970
         cookie.expiryTime = DateTime.fromMicrosecondsSinceEpoch(0);
       }
-    } else if (attrs.containsKey("expires")) {
+    } else if (containsKey("Expires")) {
       // Otherwise:
       // If Expires is present
       // Cookie is persistent
@@ -352,7 +355,7 @@ class CookieStore {
 
       // Parse the date, I'm trying to be as permissive as possible. I hate
       // the internet so fucking much
-      String expires = attrs["expires"]!;
+      String expires = attr("Expires")!;
 
       final Iterable<({String fullname, String abbreviation})> weekdays = [
         "Monday",
@@ -393,8 +396,8 @@ class CookieStore {
     }
 
     // Step 4
-    if (attrs.containsKey("domain")) {
-      cookie.domain = attrs["domain"]!;
+    if (containsKey("Domain")) {
+      cookie.domain = attr("domain")!;
     }
 
     // Step 5
@@ -406,7 +409,7 @@ class CookieStore {
         return false;
       } else {
         cookie.hostOnly = false;
-        cookie.domain = attrs["domain"]!;
+        cookie.domain = attr("domain")!;
       }
     } else {
       cookie.hostOnly = true;
@@ -414,8 +417,8 @@ class CookieStore {
     }
 
     // Step 7
-    if (attrs.containsKey("path")) {
-      cookie.path = attrs["path"]!;
+    if (containsKey("Path")) {
+      cookie.path = attr("Path")!;
     } else {
       cookie.path = requestPath;
     }

--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -422,11 +422,11 @@ class CookieStore {
       cookie.path = "/";
     }
     // 5.1.4 Step 3
-    if (cookie.path.allMatches("/").length == 1) {
+    else if (cookie.path.allMatches("/").length == 1) {
       cookie.path = "/";
     }
     // 5.1.4 Step 4
-    if (cookie.path != "/") {
+    else {
       // Up to but not including the last "/" in the current cookie path
       cookie.path = cookie.path.substring(0, cookie.path.lastIndexOf("/"));
     }

--- a/test/cookies_test.dart
+++ b/test/cookies_test.dart
@@ -166,5 +166,17 @@ void main() {
       store.updateCookies("test=true", requestDomain, "/");
       check("/", "lang=en/ca;test=true");
     });
+
+    test('with path attribute', () {
+      assert(store.updateCookies('PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3; Path=/example/', requestDomain, "/sample-directory/sample.php"));
+      assert(store.updateCookies("lang=en/ca; Path=/login/path/page", requestDomain, "/sample-directory/sample.php"));
+      assert(store.updateCookies('test=true; Path=/', requestDomain, "/sample-directory/sample.php"));
+
+      check('/example', 'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;test=true', 'exactly matches path attribute');
+      check('/example/subpath/with/page', 'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;test=true', 'subpath of path attribute');
+      check('/', 'test=true', 'not a subpath of path attribute');
+      check('/login', 'test=true', 'path is below / but not part of example');
+      check('/login/path', 'lang=en/ca;test=true', 'path is below / but not part of example');
+    });
   });
 }

--- a/test/cookies_test.dart
+++ b/test/cookies_test.dart
@@ -142,6 +142,25 @@ void main() {
     expect(store.cookies.length, 0);
   });
 
+  test('End to end tests', () {
+    CookieStore store = CookieStore();
+    store.updateCookies("PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3", "example.com", "/sample-directory/sample.php");
+    String cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/"));
+    // the cookie was set on "/sample-directory/" so should not be used for "/"
+    expect("", cookieHeader);
+
+    store.updateCookies("lang=en/ca", "example.com", "/");
+    cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/"));
+    expect("lang=en/ca", cookieHeader);
+
+    cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/sample-directory"));
+    expect("PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;lang=en/ca", cookieHeader);
+
+    store.updateCookies("test=true", "example.com", "/");
+    cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/example"));
+    expect("lang=en/ca;test=true", cookieHeader);
+  });
+
   group('Path handling', () {
     const requestDomain = 'example.com';
     late CookieStore store;


### PR DESCRIPTION
When using [http session](https://pub.dev/packages/http_session) I found some issues with path handling
- explicit path attributes (with "Path") were not handling as the lower case transformation your code expected did not happen
- path handling (after 444a010) was incorrect according to RFC (better explained at [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#define_where_cookies_are_sent))

Note: I also fiddled around with the day replacement - the named tuples require a newer version of Dart, so feel free to change this back (or only cherry pick my changes) 