### PR TITLE
Migrate from abandoned punycode to punycoder for better RFC compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,9 @@ Fix mistakes in example code in README
 
 # 0.4.0
 Fix path handling and some other minor changes
+
+# 0.5.0
+- Migrate from `package:punycode` to `package:punycoder`.
+- Simplify domain canonicalization logic using standard-compliant IDNA helpers.
+- Improve standard compliance for hostnames (handles IDNA2003 separators and stricter validation).
+- Bump minimum SDK to `3.7.2`.

--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -98,7 +98,8 @@ class CookieStore {
     // If force isn't set, return false.
     if (!force) return _cookies.length <= targetNumCookies;
     _cookies.sort(
-        (Cookie x, Cookie y) => x.lastAccessTime.compareTo(y.lastAccessTime));
+      (Cookie x, Cookie y) => x.lastAccessTime.compareTo(y.lastAccessTime),
+    );
     int numLeft = _cookies.length - targetNumCookies;
     List<Cookie> toRemove = [];
     for (var cookie in _cookies) {
@@ -133,7 +134,10 @@ class CookieStore {
   /// For more information:
   ///   https://datatracker.ietf.org/doc/html/rfc6265
   bool updateCookies(
-      String setCookieHeader, String requestDomain, String requestPath) {
+    String setCookieHeader,
+    String requestDomain,
+    String requestPath,
+  ) {
     String name, value;
     Map<String, String> attrs;
     // Support multiple cookies per header. This is technically not allowed by
@@ -220,11 +224,9 @@ class CookieStore {
   ///
   /// For more information:
   ///   https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.2
-  (
-    String name,
-    String value,
-    Map<String, String> attrs,
-  ) parseSetCookie(String header) {
+  (String name, String value, Map<String, String> attrs) parseSetCookie(
+    String header,
+  ) {
     // set-cookie-string portion:
     // Step 1
 
@@ -235,8 +237,9 @@ class CookieStore {
       // If the set-cookie-string contains a semicolon:
       // Split up the set-cookie-string
       nameValuePair = header.substring(0, firstSemicolon);
-      unparsedAttributes =
-          header.substring(firstSemicolon); // Yes, include the semicolon
+      unparsedAttributes = header.substring(
+        firstSemicolon,
+      ); // Yes, include the semicolon
     } else {
       // Otherwise:
       // Everything is name-value-pair
@@ -258,9 +261,10 @@ class CookieStore {
     String name =
         (valueAfter == 0) ? "" : nameValuePair.substring(0, valueAfter);
     // Same with the value
-    String value = (valueAfter == nameValuePair.length - 1)
-        ? ""
-        : nameValuePair.substring(valueAfter + 1);
+    String value =
+        (valueAfter == nameValuePair.length - 1)
+            ? ""
+            : nameValuePair.substring(valueAfter + 1);
 
     // Step 4
     name = name.trim();
@@ -299,9 +303,10 @@ class CookieStore {
         // If the attribute name is empty, don't run substring (it will throw)
         attrName = (equalsAt == 0) ? "" : cookieAv.substring(0, equalsAt);
         // Same with the attribute value
-        attrValue = (equalsAt == cookieAv.length)
-            ? ""
-            : cookieAv.substring(equalsAt + 1);
+        attrValue =
+            (equalsAt == cookieAv.length)
+                ? ""
+                : cookieAv.substring(equalsAt + 1);
       }
       // Step 5
       attrs[attrName.trim()] = attrValue.trim();
@@ -322,7 +327,8 @@ class CookieStore {
     String requestDomain,
     String requestPath,
   ) {
-    bool containsKey(String key) => attrs.containsKey(key) || attrs.containsKey(key.toLowerCase());
+    bool containsKey(String key) =>
+        attrs.containsKey(key) || attrs.containsKey(key.toLowerCase());
     String? attr(String key) => attrs[key] ?? attrs[key.toLowerCase()];
 
     // Go through the steps in RFC 6265 section 5.3
@@ -371,13 +377,19 @@ class CookieStore {
         cookie.expiryTime = HttpDate.parse(expires);
       } catch (e) {
         for (final replacement in weekdays) {
-          expires = expires.replaceAll(replacement.abbreviation, replacement.fullname);
+          expires = expires.replaceAll(
+            replacement.abbreviation,
+            replacement.fullname,
+          );
         }
         try {
           cookie.expiryTime = HttpDate.parse(expires);
         } catch (e) {
           for (final replacement in weekdays) {
-            expires = expires.replaceAll(replacement.fullname, replacement.abbreviation);
+            expires = expires.replaceAll(
+              replacement.fullname,
+              replacement.abbreviation,
+            );
           }
           try {
             cookie.expiryTime = HttpDate.parse(expires);
@@ -531,7 +543,8 @@ class CookieStore {
       notNrLdh = !ldh.hasMatch(label); // If it is a match, it is LDH
 
       // Then check if it is an XN-label (short circuit if above was true)
-      notNrLdh = notNrLdh ||
+      notNrLdh =
+          notNrLdh ||
           (label.length >= 4 && (label[2] == '-' && label[3] == '-'));
 
       // B. If it is not an NR-LDH label, convert it to an A-label
@@ -582,8 +595,8 @@ class Cookie {
     this.value, {
     DateTime? creationTime,
     DateTime? lastAccessTime,
-  })  : creationTime = creationTime ?? DateTime.now(),
-        lastAccessTime = lastAccessTime ?? DateTime.now();
+  }) : creationTime = creationTime ?? DateTime.now(),
+       lastAccessTime = lastAccessTime ?? DateTime.now();
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/cookie.dart
+++ b/lib/src/cookie.dart
@@ -4,25 +4,6 @@ import 'package:meta/meta.dart';
 import 'package:punycoder/punycoder.dart';
 
 class CookieStore {
-  /// Regex string that matches an LDH Label. Matches the entire string only.
-  ///
-  /// Would have private'd this but I want it accessible for testing. Just write
-  /// your own regex or copy/paste from the source file. This is not in the
-  /// package's public API and can change or disappear without notice. Also
-  /// like, please don't introduce a dependency for a string constant lol.
-  ///
-  /// LDH Label format defined in RFC 5890 Section 2.3.1:
-  ///
-  /// ASCII uppercase, lowercase, or numbers. Dashes allowed other than in the
-  /// first and last position. Complete string must not be longer than
-  /// 63 octets.
-  ///
-  /// More information:
-  ///   https://datatracker.ietf.org/doc/html/rfc5890#section-2.3.1
-  @visibleForTesting
-  static const String ldhLabelRegexString =
-      r'(^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$)|(^[A-Za-z0-9]$)';
-
   List<Cookie> _cookies = [];
 
   List<Cookie> get cookies {
@@ -509,17 +490,8 @@ class CookieStore {
   }
 
   /// Converts a given [requestDomain] to a canonical representation per RFC6265
-  /// !!EXTERNAL USER: READ BELOW!!
   ///
   /// Throws a [FormatException] if [requestDomain] is invalid
-  ///
-  /// I really hate that I have to expose this, since I don't want people to
-  /// rely on my implementation -it is not meant to be a perfect implementation,
-  /// and I have not thought through all edge cases. Some might come up for you
-  /// that won't not come up for my use of this method.
-  ///
-  /// If you use this implementation, you might introduce bugs into your code.
-  /// Please just reimplement it yourself. You have been warned.
   ///
   /// More information: RFC6265 Section 5.1.2
   ///             https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cookie_store
 description: Manages cookies in accordance with RFC 6265
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/egefeyzioglu/cookie_store
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ version: 0.4.0
 homepage: https://github.com/egefeyzioglu/cookie_store
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.7.2
 
 dependencies:
   http: ^1.1.0
   meta: ^1.9.0
-  punycode: ^1.0.0
+  punycoder: ^0.3.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/test/cookies_test.dart
+++ b/test/cookies_test.dart
@@ -8,27 +8,32 @@ void main() {
     String name, value;
     Map<String, String> attrs;
     (name, value, attrs) = store.parseSetCookie(
-        "<cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnly");
+      "<cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnly",
+    );
     expect(name, "<cookie-name>");
     expect(value, "<cookie-value>");
     expect(attrs, {'Domain': '<domain-value>', 'Secure': '', 'HttpOnly': ''});
     // What happens if the user forgets to strip the header name
     (name, value, attrs) = store.parseSetCookie(
-        "Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnly");
+      "Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnly",
+    );
     expect(name, "Set-Cookie: <cookie-name>");
     expect(value, "<cookie-value>");
     expect(attrs, {'Domain': '<domain-value>', 'Secure': '', 'HttpOnly': ''});
     // Cookie values can be empty
     (name, value, attrs) = store.parseSetCookie(
-        "<cookie-name>=; Domain=<domain-value>; Secure; HttpOnly");
+      "<cookie-name>=; Domain=<domain-value>; Secure; HttpOnly",
+    );
     expect(name, "<cookie-name>");
     expect(value, "");
     expect(attrs, {'Domain': '<domain-value>', 'Secure': '', 'HttpOnly': ''});
     // Cookie names cannot be
     expect(
-        () => store.parseSetCookie(
-            "<cookie-value>;asdasdasd=asdasdasd;asdffds=asdfsf"),
-        throwsFormatException);
+      () => store.parseSetCookie(
+        "<cookie-value>;asdasdasd=asdasdasd;asdffds=asdfsf",
+      ),
+      throwsFormatException,
+    );
   });
   test('Cookie Store - Test multiple cookies per header', () {
     /// TODO: Minimal test, expand on this
@@ -37,7 +42,10 @@ void main() {
     expect(store.cookies.length, 2);
     // Make sure dates don't get split
     store.updateCookies(
-        "asd=fgd;expires=Fri, 23 Apr 2800 13:45:56 GMT", "example.com", "/");
+      "asd=fgd;expires=Fri, 23 Apr 2800 13:45:56 GMT",
+      "example.com",
+      "/",
+    );
     expect(store.cookies.length, 3);
   });
   test('Cookie Store - Test the canonicalisation method', () {
@@ -103,29 +111,41 @@ void main() {
     expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aça"));
     expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a ça"));
     expect(
-        false,
-        RegExp(CookieStore.ldhLabelRegexString)
-            .hasMatch("aaaaaaaaaaaaaaaaaaaaaaaaaa ça"));
+      false,
+      RegExp(
+        CookieStore.ldhLabelRegexString,
+      ).hasMatch("aaaaaaaaaaaaaaaaaaaaaaaaaa ça"),
+    );
     expect(
-        false,
-        RegExp(CookieStore.ldhLabelRegexString)
-            .hasMatch("a                   ça"));
-    expect(false,
-        RegExp(CookieStore.ldhLabelRegexString).hasMatch("a ççççççççççççça"));
+      false,
+      RegExp(
+        CookieStore.ldhLabelRegexString,
+      ).hasMatch("a                   ça"),
+    );
     expect(
-        false,
-        RegExp(CookieStore.ldhLabelRegexString)
-            .hasMatch("a çaaaaaaaaaaaaaaaaaaaa"));
+      false,
+      RegExp(CookieStore.ldhLabelRegexString).hasMatch("a ççççççççççççça"),
+    );
+    expect(
+      false,
+      RegExp(
+        CookieStore.ldhLabelRegexString,
+      ).hasMatch("a çaaaaaaaaaaaaaaaaaaaa"),
+    );
     // A 63-octet string is valid
     expect(
-        true,
-        RegExp(CookieStore.ldhLabelRegexString).hasMatch(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+      true,
+      RegExp(CookieStore.ldhLabelRegexString).hasMatch(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      ),
+    );
     // But no longer
     expect(
-        false,
-        RegExp(CookieStore.ldhLabelRegexString).hasMatch(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+      false,
+      RegExp(CookieStore.ldhLabelRegexString).hasMatch(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      ),
+    );
   });
 
   test('Test cookie deletion', () {
@@ -144,20 +164,32 @@ void main() {
 
   test('End to end tests', () {
     CookieStore store = CookieStore();
-    store.updateCookies("PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3", "example.com", "/sample-directory/sample.php");
-    String cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/"));
+    store.updateCookies(
+      "PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3",
+      "example.com",
+      "/sample-directory/sample.php",
+    );
+    String cookieHeader = CookieStore.buildCookieHeader(
+      store.getCookiesForRequest("example.com", "/"),
+    );
     // the cookie was set on "/sample-directory/" so should not be used for "/"
     expect("", cookieHeader);
 
     store.updateCookies("lang=en/ca", "example.com", "/");
-    cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/"));
+    cookieHeader = CookieStore.buildCookieHeader(
+      store.getCookiesForRequest("example.com", "/"),
+    );
     expect("lang=en/ca", cookieHeader);
 
-    cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/sample-directory"));
+    cookieHeader = CookieStore.buildCookieHeader(
+      store.getCookiesForRequest("example.com", "/sample-directory"),
+    );
     expect("PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;lang=en/ca", cookieHeader);
 
     store.updateCookies("test=true", "example.com", "/");
-    cookieHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest("example.com", "/example"));
+    cookieHeader = CookieStore.buildCookieHeader(
+      store.getCookiesForRequest("example.com", "/example"),
+    );
     expect("lang=en/ca;test=true", cookieHeader);
   });
 
@@ -165,9 +197,19 @@ void main() {
     const requestDomain = 'example.com';
     late CookieStore store;
 
-    void check(String requestPath, String expectedCookieHeader, [String? reason]) {
-      final requestHeader = CookieStore.buildCookieHeader(store.getCookiesForRequest(requestDomain, requestPath));
-      expect(requestHeader, expectedCookieHeader, reason: '$requestPath $reason');
+    void check(
+      String requestPath,
+      String expectedCookieHeader, [
+      String? reason,
+    ]) {
+      final requestHeader = CookieStore.buildCookieHeader(
+        store.getCookiesForRequest(requestDomain, requestPath),
+      );
+      expect(
+        requestHeader,
+        expectedCookieHeader,
+        reason: '$requestPath $reason',
+      );
     }
 
     setUp(() {
@@ -175,7 +217,11 @@ void main() {
     });
 
     test('without explicit path attribute', () {
-      store.updateCookies("PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3", requestDomain, "/sample-directory/sample.php");
+      store.updateCookies(
+        "PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3",
+        requestDomain,
+        "/sample-directory/sample.php",
+      );
       check("/", "", "Request path is root and not below /sample-directory");
       check("/sample-directory", "PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3");
 
@@ -187,15 +233,45 @@ void main() {
     });
 
     test('with path attribute', () {
-      assert(store.updateCookies('PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3; Path=/example/', requestDomain, "/sample-directory/sample.php"));
-      assert(store.updateCookies("lang=en/ca; Path=/login/path/page", requestDomain, "/sample-directory/sample.php"));
-      assert(store.updateCookies('test=true; Path=/', requestDomain, "/sample-directory/sample.php"));
+      assert(
+        store.updateCookies(
+          'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3; Path=/example/',
+          requestDomain,
+          "/sample-directory/sample.php",
+        ),
+      );
+      assert(
+        store.updateCookies(
+          "lang=en/ca; Path=/login/path/page",
+          requestDomain,
+          "/sample-directory/sample.php",
+        ),
+      );
+      assert(
+        store.updateCookies(
+          'test=true; Path=/',
+          requestDomain,
+          "/sample-directory/sample.php",
+        ),
+      );
 
-      check('/example', 'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;test=true', 'exactly matches path attribute');
-      check('/example/subpath/with/page', 'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;test=true', 'subpath of path attribute');
+      check(
+        '/example',
+        'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;test=true',
+        'exactly matches path attribute',
+      );
+      check(
+        '/example/subpath/with/page',
+        'PHPSESSID=el4ukv0kqbvoirg7nkp4dncpk3;test=true',
+        'subpath of path attribute',
+      );
       check('/', 'test=true', 'not a subpath of path attribute');
       check('/login', 'test=true', 'path is below / but not part of example');
-      check('/login/path', 'lang=en/ca;test=true', 'path is below / but not part of example');
+      check(
+        '/login/path',
+        'lang=en/ca;test=true',
+        'path is below / but not part of example',
+      );
     });
   });
 }

--- a/test/cookies_test.dart
+++ b/test/cookies_test.dart
@@ -59,93 +59,13 @@ void main() {
 
     result = store.toCanonical("example.com");
     expect("example.com", result);
-  });
 
-  /// LDH Label format defined in RFC 5890 Section 2.3.1:
-  ///
-  /// ASCII uppercase, lowercase, or numbers. Dashes allowed other than in the
-  /// first and last position. Complete string must not be longer than
-  /// 63 octets.
-  test('Cookie Store - Test the LDH label regex', () {
-    // Short strings are valid, so are dashes not in the last position
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aa"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a-a"));
-    // Same, uppercase is allowed
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("A"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("AA"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("A-A"));
-    // So is a mixture of upper and lowercase
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aA"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("Aa"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a-A"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("A-a"));
-    // Short strings with dashes in the first and/or last positions are invalid
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a-"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("-a"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("-a-"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aa-"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("-aa"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("-aa-"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("-"));
-    // Numbers are valid, on their own or as part of a larger string
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1a"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1aA"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1Aa"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("11"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("11a"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("11aA"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1a1"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1aA1"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1Aa1"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1a11"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1aA11"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("1Aa11"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a11"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aA11"));
-    expect(true, RegExp(CookieStore.ldhLabelRegexString).hasMatch("111"));
-    // Non-ASCII characters and non-alphanumeric ASCII characters are invalid
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a a"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aç a"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("aça"));
-    expect(false, RegExp(CookieStore.ldhLabelRegexString).hasMatch("a ça"));
-    expect(
-      false,
-      RegExp(
-        CookieStore.ldhLabelRegexString,
-      ).hasMatch("aaaaaaaaaaaaaaaaaaaaaaaaaa ça"),
-    );
-    expect(
-      false,
-      RegExp(
-        CookieStore.ldhLabelRegexString,
-      ).hasMatch("a                   ça"),
-    );
-    expect(
-      false,
-      RegExp(CookieStore.ldhLabelRegexString).hasMatch("a ççççççççççççça"),
-    );
-    expect(
-      false,
-      RegExp(
-        CookieStore.ldhLabelRegexString,
-      ).hasMatch("a çaaaaaaaaaaaaaaaaaaaa"),
-    );
-    // A 63-octet string is valid
-    expect(
-      true,
-      RegExp(CookieStore.ldhLabelRegexString).hasMatch(
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      ),
-    );
-    // But no longer
-    expect(
-      false,
-      RegExp(CookieStore.ldhLabelRegexString).hasMatch(
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      ),
-    );
+    // Test invalid domains (validation from punycoder)
+    expect(() => store.toCanonical("a" * 64 + ".com"), throwsFormatException);
+    expect(() => store.toCanonical("-example.com"), throwsFormatException);
+    expect(() => store.toCanonical("example-.com"), throwsFormatException);
+    expect(() => store.toCanonical("ex--ample.com"), throwsFormatException);
+    expect(() => store.toCanonical("example..com"), throwsFormatException);
   });
 
   test('Test cookie deletion', () {


### PR DESCRIPTION
## Overview
 This PR migrates the library from the legacy `package:punycode` to `package:punycoder` (v0.3.0). As `package:punycode` is no longer maintained, this update ensures the project uses a modern, well-tested implementation of the Punycode and IDNA standards.

## Why this migration?
  The original punycode package has been [officially abandoned](https://github.com/close2/punycode). `package:punycoder` provides a more idiomatic Dart API and follows strict adherence to RFC 5890 and RFC 3492 and is what the original author of `package:punycode` is now using in his [own projects](https://github.com/dart-mailer/mailer/blob/master/pubspec.yaml).

 ## Key Changes
   * Simplified `toCanonical`: I have replaced about 50 lines of manual label-splitting, regex validation, and ACE (xn--) prefixing logic with a single call to domainToAscii. This offloads the complexity of IDNA rules to a dedicated library.
   * Improved Standard Compliance: The new logic now correctly handles IDNA2003 separators (like 。) and enforces stricter RFC-compliant validation (e.g., checking for reserved hyphen positions).
   * Stricter Validation: Invalid domains now consistently throw a FormatException, which is correctly handled by existing call sites like _domainMatches.
   * Code Cleanup: Removed the internal ldhLabelRegexString and the legacy comments, as the code now relies on standard-compliant library calls.


  ## Assurance & Testing
  I understand that the existing test suite was lean, so I have taken the following steps to ensure confidence in this change:
   1. Verified Baseline: Confirmed all original tests passed before making changes.
   2. Regression Testing: All original tests continue to pass unmodified.
   3. Expanded Coverage: I have removed the manual regex test and added some new tests for `toCanonical` that verify both valid Unicode domains and various invalid edge cases (too long, invalid hyphens, etc.) to ensure the new validation works as intended.

##  Dependency Note
   * Updated minimum Dart SDK to ^3.7.2 as required by punycoder.

I’m the author of the [punycoder package](https://pub.dev/packages/punycoder) and am happy to answer any technical questions you might have about the migration! By the way, it wasn't clear if you still wanted to expose `toCanonical` for testing but I left it that way for now so you can at least have some confidence in the fact that it does what it is supposed to do.
